### PR TITLE
Add ability to run systemd service as user

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -60,6 +60,10 @@ RS_SITE_TEMPLATE_PATH=$(TOP)/site-template
 # Each service need one space between them, and backslash must be double backslash
 RS_SYSTEMD_SERVICES:=channelfinder.service
 
+# If you want to run this as a user level systemd service
+# You can set this to: --user
+RS_SYSTEMD_USER:=
+
 # These allow developers to override the CONFIG_SITE variable
 # settings without having to modify the configure/CONFIG_SITE
 # file itself.

--- a/configure/CONFIG_SRC
+++ b/configure/CONFIG_SRC
@@ -33,3 +33,9 @@ VARS_EXCLUDES+=INSTALL_PROGRAM
 VARS_EXCLUDES+=INSTALL_DATA
 #
 #
+
+# These allow developers to override the CONFIG_SRC variable
+# settings without having to modify the configure/CONFIG_SRC
+# file itself.
+-include $(TOP)/../CONFIG_SRC.local
+-include $(TOP)/configure/CONFIG_SRC.local

--- a/configure/RULES_SYSTEMD
+++ b/configure/RULES_SYSTEMD
@@ -11,7 +11,7 @@ install_systemd_RULES:=$(addprefix install., $(systemd_RULES_NAMES))
 show_install_systemd_RULES:=$(addsuffix .show, $(install_systemd_RULES))
 
 sd_install: conf.systemd install.systemd
-	$(QUIET)$(SUDO) systemctl daemon-reload
+	$(QUIET)$(SUDO) systemctl $(RS_SYSTEMD_USER) daemon-reload
 
 .PHONY: conf.systemd conf.systemd.show
 
@@ -47,19 +47,19 @@ install.systemd0.show:
 #
 #	
 sd_status:
-	$(QUIET) systemctl status -l $(RS_SYSTEMD_FILENAME) | cat -b
+	$(QUIET) systemctl status $(RS_SYSTEMD_USER) -l $(RS_SYSTEMD_FILENAME) | cat -b
 
 #
 sd_start:
-	$(QUIET)$(SUDO) systemctl start $(RS_SYSTEMD_FILENAME)
+	$(QUIET)$(SUDO) systemctl start $(RS_SYSTEMD_USER) $(RS_SYSTEMD_FILENAME)
 #
 # We ignore its error
 sd_stop:
-	-$(QUIET)$(SUDO) systemctl stop $(RS_SYSTEMD_FILENAME)
+	-$(QUIET)$(SUDO) systemctl stop $(RS_SYSTEMD_USER) $(RS_SYSTEMD_FILENAME)
 #
 #
 sd_restart:
-	$(QUIET)$(SUDO) systemctl restart $(RS_SYSTEMD_FILENAME)
+	$(QUIET)$(SUDO) systemctl restart $(RS_SYSTEMD_USER) $(RS_SYSTEMD_FILENAME)
 #
 # We ignore its error
 sd_clean:
@@ -67,10 +67,10 @@ sd_clean:
 #
 #
 sd_enable:
-	$(if $(wildcard $(SYSTEMD_PATH)/$(RS_SYSTEMD_FILENAME)), $(SUDO) systemctl enable $(RS_SYSTEMD_FILENAME))
+	$(if $(wildcard $(SYSTEMD_PATH)/$(RS_SYSTEMD_FILENAME)), $(SUDO) systemctl enable $(RS_SYSTEMD_USER) $(RS_SYSTEMD_FILENAME))
 #
 #
 sd_disable:
-	$(if $(wildcard $(SYSTEMD_PATH)/$(RS_SYSTEMD_FILENAME)), $(SUDO) systemctl disable $(RS_SYSTEMD_FILENAME))
+	$(if $(wildcard $(SYSTEMD_PATH)/$(RS_SYSTEMD_FILENAME)), $(SUDO) systemctl disable $(RS_SYSTEMD_USER) $(RS_SYSTEMD_FILENAME))
 #
 #


### PR DESCRIPTION
Hi @jeonghanlee 

These changes allow us to run the recsync.service as a user level systemd service and avoid needing sudo for recsync deployment. By default, RS_SYSTEMD_USER is blank so should have no impact on existing set ups